### PR TITLE
feat(cards): enhance card price formatting and update DTOs for better handling of null values

### DIFF
--- a/app/mappers/card_mapper.ts
+++ b/app/mappers/card_mapper.ts
@@ -2,41 +2,60 @@ import Card from '#models/card'
 import { CardPricesOutputDTO } from '#types/card_dto_type'
 
 export default class CardMapper {
+  private static formatPriceValue(value: string | number | null): string {
+    if (value === null || value === '0.00' || value === 0 || value === '0') {
+      return 'unknown'
+    }
+    return value.toString()
+  }
+
   public static toCardPricesOutputDTO(card: Card): CardPricesOutputDTO {
     const cardMarketPrices = card.cardMarketPrices.length > 0 ? card.cardMarketPrices[0] : null
     const tcgPlayerReporting =
       card.tcgPlayerReportings.length > 0 ? card.tcgPlayerReportings[0] : null
 
-    if (cardMarketPrices === null) {
-      return {
-        id: card.id,
-        cardMarketReporting: null,
-        tcgPlayerReporting: tcgPlayerReporting,
-      }
+    const result: CardPricesOutputDTO = {
+      id: card.id,
+      cardMarketReporting: null,
+      tcgPlayerReporting: null,
     }
 
-    const reverseHoloPrice = cardMarketPrices.reverseHoloTrend?.toString() || null
-    const normal = cardMarketPrices.trendPrice?.toString() || null
+    // Format CardMarket prices
+    if (cardMarketPrices) {
+      const reverseHoloPrice = cardMarketPrices.reverseHoloTrend?.toString() || null
+      const normal = cardMarketPrices.trendPrice?.toString() || null
 
-    return {
-      id: card.id,
-      cardMarketReporting: {
+      result.cardMarketReporting = {
         id: cardMarketPrices.id,
         url: cardMarketPrices.url,
         cardMarketPrices: [
           {
             id: cardMarketPrices.id,
             type: 'normal',
-            market: normal,
+            market: this.formatPriceValue(normal),
           },
           {
             id: cardMarketPrices.id,
             type: 'reverseHolo',
-            market: reverseHoloPrice,
+            market: this.formatPriceValue(reverseHoloPrice),
           },
         ],
-      },
-      tcgPlayerReporting: tcgPlayerReporting,
+      }
     }
+
+    // Format TCGPlayer prices
+    if (tcgPlayerReporting) {
+      result.tcgPlayerReporting = {
+        id: tcgPlayerReporting.id,
+        url: tcgPlayerReporting.url,
+        tcgPlayerPrices: tcgPlayerReporting.tcgPlayerPrices.map((price) => ({
+          id: price.id,
+          type: price.type,
+          market: this.formatPriceValue(price.market),
+        })),
+      }
+    }
+
+    return result
   }
 }

--- a/app/types/card_dto_type.ts
+++ b/app/types/card_dto_type.ts
@@ -1,5 +1,5 @@
-import TcgPlayerReporting from '#models/tcg_player_reporting'
 import { CardMarketPriceDTO } from './card_market_price_dto_type.js'
+import { TcgPlayerReportingDTO } from './tcg_player_price_dto_type.js'
 
 export type CardPricesOutputDTO = {
   id: string
@@ -8,5 +8,5 @@ export type CardPricesOutputDTO = {
     url: string | null
     cardMarketPrices: Array<CardMarketPriceDTO>
   } | null
-  tcgPlayerReporting: TcgPlayerReporting | null
+  tcgPlayerReporting: TcgPlayerReportingDTO | null
 }

--- a/app/types/tcg_player_price_dto_type.ts
+++ b/app/types/tcg_player_price_dto_type.ts
@@ -1,0 +1,11 @@
+export type TcgPlayerPriceDTO = {
+  id: number
+  type: string
+  market: string | null
+}
+
+export type TcgPlayerReportingDTO = {
+  id: number
+  url: string | null
+  tcgPlayerPrices: Array<TcgPlayerPriceDTO>
+}

--- a/tests/unit/mappers/card_mapper.spec.ts
+++ b/tests/unit/mappers/card_mapper.spec.ts
@@ -62,7 +62,7 @@ test.group('CardMapper', (group) => {
           id: 1234567890,
           url: 'https://cardmarket.com/base1-0',
           trendPrice: null,
-          reverseHoloTrend: null,
+          reverseHoloTrend: 0.0,
           cardId: 'base1-0',
         })
       )
@@ -73,10 +73,11 @@ test.group('CardMapper', (group) => {
             url: 'https://tcgplayer.com/base1-0',
             cardId: 'base1-0',
           })
-          .with('tcgPlayerPrices', 2, (tcgPlayerPrices) =>
+          .with('tcgPlayerPrices', 3, (tcgPlayerPrices) =>
             tcgPlayerPrices.merge([
               { id: 1234567890, type: 'normal', market: 10.5 },
               { id: 1234567891, type: 'holofoil', market: 15.75 },
+              { id: 1234567892, type: 'reverseHolofoil', market: 0.0 },
             ])
           )
       )
@@ -89,16 +90,18 @@ test.group('CardMapper', (group) => {
 
     assert.equal(result.cardMarketReporting?.cardMarketPrices[0].id, 1234567890)
     assert.equal(result.cardMarketReporting?.cardMarketPrices[0].type, 'normal')
-    assert.isNull(result.cardMarketReporting?.cardMarketPrices[0].market)
+    assert.equal(result.cardMarketReporting?.cardMarketPrices[0].market, 'unknown')
 
     assert.equal(result.cardMarketReporting?.cardMarketPrices[1].id, 1234567890)
     assert.equal(result.cardMarketReporting?.cardMarketPrices[1].type, 'reverseHolo')
-    assert.isNull(result.cardMarketReporting?.cardMarketPrices[1].market)
+    assert.equal(result.cardMarketReporting?.cardMarketPrices[1].market, 'unknown')
 
     assert.equal(result.tcgPlayerReporting?.id, 1234567890)
     assert.equal(result.tcgPlayerReporting?.url, 'https://tcgplayer.com/base1-0')
     assert.isArray(result.tcgPlayerReporting?.tcgPlayerPrices)
-    assert.equal(result.tcgPlayerReporting?.tcgPlayerPrices.length, 2)
+    assert.equal(result.tcgPlayerReporting?.tcgPlayerPrices.length, 3)
+
+    assert.equal(result.tcgPlayerReporting?.tcgPlayerPrices[2]?.market, 'unknown')
   })
 
   test('toCardPricesOutputDTO - should handle empty card price data', async ({ assert }) => {


### PR DESCRIPTION
## 📝 Description

Cette PR améliore l'expérience utilisateur en formatant les valeurs de prix nulles ou égales à zéro (0.00) dans les réponses de données de prix des cartes pour afficher "unknown" (inconnu) plutôt que de montrer des valeurs vides ou des zéros potentiellement trompeurs. Lorsque les données de prix du marché sont manquantes ou pas encore disponibles, les utilisateurs verront maintenant une indication claire plutôt qu'une valeur qui pourrait suggérer que la carte est gratuite ou sans valeur.

Related task : [ATL-21](https://sleeved.atlassian.net/browse/ATL-21)

## 🔄 Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📸 Screenshots / Demo

Avant :
`
"tcgPlayerPrices": [
  {
    "id": 350158,
    "type": "1stEditionHolofoil",
    "market": null
  },
  {
    "id": 350159,
    "type": "reverseHolofoil",
    "market": "0.00"
  }
]
`
Après :
`
"tcgPlayerPrices": [
  {
    "id": 350158,
    "type": "1stEditionHolofoil",
    "market": "unknown"
  },
  {
    "id": 350159,
    "type": "reverseHolofoil",
    "market": "unknown"
  }
]
`

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Unit tests added/updated
- [ ] Integration tests passing
- [ ] Performance considerations addressed
- [ ] Documentation updated (if applicable)
- [ ] Database migrations added (if applicable)

## 📋 Notes for reviewers

La modification n'affecte que la présentation des données de prix dans les réponses API et ne modifie aucune valeur en base de données. La transformation des données de prix est gérée par une nouvelle méthode d'aide formatPriceValue dans la classe CardMapper, qui convertit à la fois les valeurs nulles et les chaînes "0.00" en "unknown".

[ATL-21]: https://sleeved.atlassian.net/browse/ATL-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ