### PR TITLE
ATL-68 : Filter Mapper (label/name -> value)

### DIFF
--- a/app/controllers/product/filters_controller.ts
+++ b/app/controllers/product/filters_controller.ts
@@ -1,3 +1,4 @@
+import FilterMapper from '#mappers/filter_mapper'
 import ArtistService from '#services/artist_service'
 import RarityService from '#services/rarity_service'
 import SubtypeService from '#services/subtype_service'
@@ -23,13 +24,13 @@ export default class FiltersController {
       this.typeService.getAllTypes(),
     ])
 
-    const cardFilters: FilterCardsOutputDTO = {
+    const filters: FilterCardsOutputDTO = FilterMapper.toNormalizedFilterCardsOutputDTO(
       artists,
       rarities,
       subtypes,
-      types,
-    }
+      types
+    )
 
-    return response.ok(cardFilters)
+    return response.ok(filters)
   }
 }

--- a/app/mappers/filter_mapper.ts
+++ b/app/mappers/filter_mapper.ts
@@ -1,0 +1,49 @@
+import Artist from '#models/artist'
+import Rarity from '#models/rarity'
+import Subtype from '#models/subtypes'
+import Type from '#models/type'
+import { FilterCardsOutputDTO, FilterItem } from '#types/filter_cards_type'
+
+export default class FilterMapper {
+  public static toNormalizedFilterCardsOutputDTO(
+    artists: Artist[],
+    rarities: Rarity[],
+    subtypes: Subtype[],
+    types: Type[]
+  ): FilterCardsOutputDTO {
+    return {
+      artists: this.normalizeArtists(artists),
+      rarities: this.normalizeRarities(rarities),
+      subtypes: this.normalizeSubtypes(subtypes),
+      types: this.normalizeTypes(types),
+    }
+  }
+
+  private static normalizeArtists(artists: Artist[]): FilterItem[] {
+    return artists.map((artist) => ({
+      id: artist.id,
+      value: artist.name,
+    }))
+  }
+
+  private static normalizeRarities(rarities: Rarity[]): FilterItem[] {
+    return rarities.map((rarity) => ({
+      id: rarity.id,
+      value: rarity.label,
+    }))
+  }
+
+  private static normalizeSubtypes(subtypes: Subtype[]): FilterItem[] {
+    return subtypes.map((subtype) => ({
+      id: subtype.id,
+      value: subtype.label,
+    }))
+  }
+
+  private static normalizeTypes(types: Type[]): FilterItem[] {
+    return types.map((type) => ({
+      id: type.id,
+      value: type.label,
+    }))
+  }
+}

--- a/app/types/filter_cards_type.ts
+++ b/app/types/filter_cards_type.ts
@@ -1,11 +1,11 @@
-import Artist from '#models/artist'
-import Rarity from '#models/rarity'
-import Subtype from '#models/subtypes'
-import Type from '#models/type'
+export interface FilterItem {
+  id: number
+  value: string
+}
 
 export interface FilterCardsOutputDTO {
-  artists: Artist[]
-  rarities: Rarity[]
-  subtypes: Subtype[]
-  types: Type[]
+  artists: FilterItem[]
+  rarities: FilterItem[]
+  subtypes: FilterItem[]
+  types: FilterItem[]
 }

--- a/tests/functional/controllers/filters_controller.spec.ts
+++ b/tests/functional/controllers/filters_controller.spec.ts
@@ -56,14 +56,14 @@ test.group('Filters controller', (group) => {
     const result = response.body()
 
     assert.property(result.artists[0], 'id')
-    assert.property(result.artists[0], 'name')
+    assert.property(result.artists[0], 'value')
     assert.isNumber(result.artists[0].id)
-    assert.isString(result.artists[0].name)
+    assert.isString(result.artists[0].value)
 
     assert.property(result.rarities[0], 'id')
-    assert.property(result.rarities[0], 'label')
+    assert.property(result.rarities[0], 'value')
     assert.isNumber(result.rarities[0].id)
-    assert.isString(result.rarities[0].label)
+    assert.isString(result.rarities[0].value)
   })
 
   test('cards - should respond quickly', async ({ client, assert }) => {

--- a/tests/functional/services/card_service.spec.ts
+++ b/tests/functional/services/card_service.spec.ts
@@ -18,6 +18,7 @@ import { TypeFactory } from '#database/factories/type'
 import { CardFolioFactory } from '#database/factories/card_folio'
 import CardFolio from '#models/card_folio'
 import { FolioFactory } from '#database/factories/folio'
+import { TEST_AUTH_USER_ID } from '#tests/mocks/auth_service_mock'
 
 test.group('CardService', (group) => {
   group.each.setup(() => testUtils.db().withGlobalTransaction())

--- a/tests/unit/mappers/filter_mapper.spec.ts
+++ b/tests/unit/mappers/filter_mapper.spec.ts
@@ -56,35 +56,6 @@ test.group('FilterMapper', (group) => {
     assert.lengthOf(result.types, 0)
   })
 
-  test('toNormalizedFilterCardsOutputDTO - should handle multiple items', async ({ assert }) => {
-    const artists = await ArtistFactory.merge([
-      { id: 1, name: 'Ken Sugimori' },
-      { id: 2, name: 'Atsuko Nishida' },
-    ]).createMany(2)
-
-    const rarities = await RarityFactory.merge([
-      { id: 1, label: 'Common' },
-      { id: 2, label: 'Rare' },
-      { id: 3, label: 'Rare Holo' },
-    ]).createMany(3)
-
-    const result = FilterMapper.toNormalizedFilterCardsOutputDTO(artists, rarities, [], [])
-
-    assert.lengthOf(result.artists, 2)
-    assert.equal(result.artists[0].id, artists[0].id)
-    assert.equal(result.artists[0].value, 'Ken Sugimori')
-    assert.equal(result.artists[1].id, artists[1].id)
-    assert.equal(result.artists[1].value, 'Atsuko Nishida')
-
-    assert.lengthOf(result.rarities, 3)
-    assert.equal(result.rarities[0].id, rarities[0].id)
-    assert.equal(result.rarities[0].value, 'Common')
-    assert.equal(result.rarities[1].id, rarities[1].id)
-    assert.equal(result.rarities[1].value, 'Rare')
-    assert.equal(result.rarities[2].id, rarities[2].id)
-    assert.equal(result.rarities[2].value, 'Rare Holo')
-  })
-
   test('normalizeArtists - should correctly map name to value', async ({ assert }) => {
     const artists = await ArtistFactory.merge([
       { id: 1, name: 'Mitsuhiro Arita' },

--- a/tests/unit/mappers/filter_mapper.spec.ts
+++ b/tests/unit/mappers/filter_mapper.spec.ts
@@ -1,0 +1,150 @@
+import { test } from '@japa/runner'
+import FilterMapper from '#mappers/filter_mapper'
+import { ArtistFactory } from '#database/factories/artist'
+import { RarityFactory } from '#database/factories/rarity'
+import { SubtypeFactory } from '#database/factories/subtype'
+import { TypeFactory } from '#database/factories/type'
+import testUtils from '@adonisjs/core/services/test_utils'
+
+test.group('FilterMapper', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('toNormalizedFilterCardsOutputDTO - should normalize all filter types correctly', async ({
+    assert,
+  }) => {
+    const artist = await ArtistFactory.merge({ name: 'Ken Sugimori' }).create()
+    const rarity = await RarityFactory.merge({ label: 'Common' }).create()
+    const subtype = await SubtypeFactory.merge({ label: 'Basic' }).create()
+    const type = await TypeFactory.merge({ label: 'Pokémon' }).create()
+
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO(
+      [artist],
+      [rarity],
+      [subtype],
+      [type]
+    )
+
+    assert.properties(result, ['artists', 'rarities', 'subtypes', 'types'])
+
+    assert.lengthOf(result.artists, 1)
+    assert.properties(result.artists[0], ['id', 'value'])
+    assert.equal(result.artists[0].id, artist.id)
+    assert.equal(result.artists[0].value, 'Ken Sugimori')
+
+    assert.lengthOf(result.rarities, 1)
+    assert.properties(result.rarities[0], ['id', 'value'])
+    assert.equal(result.rarities[0].id, rarity.id)
+    assert.equal(result.rarities[0].value, 'Common')
+
+    assert.lengthOf(result.subtypes, 1)
+    assert.properties(result.subtypes[0], ['id', 'value'])
+    assert.equal(result.subtypes[0].id, subtype.id)
+    assert.equal(result.subtypes[0].value, 'Basic')
+
+    assert.lengthOf(result.types, 1)
+    assert.properties(result.types[0], ['id', 'value'])
+    assert.equal(result.types[0].id, type.id)
+    assert.equal(result.types[0].value, 'Pokémon')
+  })
+
+  test('toNormalizedFilterCardsOutputDTO - should handle empty arrays', ({ assert }) => {
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO([], [], [], [])
+
+    assert.lengthOf(result.artists, 0)
+    assert.lengthOf(result.rarities, 0)
+    assert.lengthOf(result.subtypes, 0)
+    assert.lengthOf(result.types, 0)
+  })
+
+  test('toNormalizedFilterCardsOutputDTO - should handle multiple items', async ({ assert }) => {
+    const artists = await ArtistFactory.merge([
+      { id: 1, name: 'Ken Sugimori' },
+      { id: 2, name: 'Atsuko Nishida' },
+    ]).createMany(2)
+
+    const rarities = await RarityFactory.merge([
+      { id: 1, label: 'Common' },
+      { id: 2, label: 'Rare' },
+      { id: 3, label: 'Rare Holo' },
+    ]).createMany(3)
+
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO(artists, rarities, [], [])
+
+    assert.lengthOf(result.artists, 2)
+    assert.equal(result.artists[0].id, artists[0].id)
+    assert.equal(result.artists[0].value, 'Ken Sugimori')
+    assert.equal(result.artists[1].id, artists[1].id)
+    assert.equal(result.artists[1].value, 'Atsuko Nishida')
+
+    assert.lengthOf(result.rarities, 3)
+    assert.equal(result.rarities[0].id, rarities[0].id)
+    assert.equal(result.rarities[0].value, 'Common')
+    assert.equal(result.rarities[1].id, rarities[1].id)
+    assert.equal(result.rarities[1].value, 'Rare')
+    assert.equal(result.rarities[2].id, rarities[2].id)
+    assert.equal(result.rarities[2].value, 'Rare Holo')
+  })
+
+  test('normalizeArtists - should correctly map name to value', async ({ assert }) => {
+    const artists = await ArtistFactory.merge([
+      { id: 1, name: 'Mitsuhiro Arita' },
+      { id: 2, name: 'Kagemaru Himeno' },
+    ]).createMany(2)
+
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO(artists, [], [], [])
+
+    assert.lengthOf(result.artists, 2)
+    assert.equal(result.artists[0].id, artists[0].id)
+    assert.equal(result.artists[0].value, 'Mitsuhiro Arita')
+    assert.equal(result.artists[1].id, artists[1].id)
+    assert.equal(result.artists[1].value, 'Kagemaru Himeno')
+  })
+
+  test('normalizeRarities - should correctly map label to value', async ({ assert }) => {
+    const rarities = await RarityFactory.merge([
+      { id: 1, label: 'Ultra Rare' },
+      { id: 2, label: 'Secret Rare' },
+    ]).createMany(2)
+
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO([], rarities, [], [])
+
+    assert.lengthOf(result.rarities, 2)
+    assert.equal(result.rarities[0].id, rarities[0].id)
+    assert.equal(result.rarities[0].value, 'Ultra Rare')
+    assert.equal(result.rarities[1].id, rarities[1].id)
+    assert.equal(result.rarities[1].value, 'Secret Rare')
+  })
+
+  test('normalizeSubtypes - should correctly map label to value', async ({ assert }) => {
+    const subtypes = await SubtypeFactory.merge([
+      { id: 1, label: 'Stage 1' },
+      { id: 2, label: 'Stage 2' },
+    ]).createMany(2)
+
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO([], [], subtypes, [])
+
+    assert.lengthOf(result.subtypes, 2)
+    assert.equal(result.subtypes[0].id, subtypes[0].id)
+    assert.equal(result.subtypes[0].value, 'Stage 1')
+    assert.equal(result.subtypes[1].id, subtypes[1].id)
+    assert.equal(result.subtypes[1].value, 'Stage 2')
+  })
+
+  test('normalizeTypes - should correctly map label to value', async ({ assert }) => {
+    const types = await TypeFactory.merge([
+      { id: 1, label: 'Fire' },
+      { id: 2, label: 'Water' },
+      { id: 3, label: 'Trainer' },
+    ]).createMany(3)
+
+    const result = FilterMapper.toNormalizedFilterCardsOutputDTO([], [], [], types)
+
+    assert.lengthOf(result.types, 3)
+    assert.equal(result.types[0].id, types[0].id)
+    assert.equal(result.types[0].value, 'Fire')
+    assert.equal(result.types[1].id, types[1].id)
+    assert.equal(result.types[1].value, 'Water')
+    assert.equal(result.types[2].id, types[2].id)
+    assert.equal(result.types[2].value, 'Trainer')
+  })
+})


### PR DESCRIPTION
## 📝 Description

Normaliser le retour JSON des éléments utilisés pour les filtres (artistes, subtypes, type, etc) en retournant pour chaque itération un ID et une VALUE.

Related task : [ATL-XXX](https://sleeved.atlassian.net/browse/ATL-XXX)

## 🔄 Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## 📸 Screenshots / Demo

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Unit tests added/updated
- [ ] Integration tests passing
- [ ] Performance considerations addressed
- [ ] Documentation updated (if applicable)
- [ ] Database migrations added (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->
