### PR TITLE
feat(webhook): event should not be processed twice

### DIFF
--- a/app/processors/webhook_processor.ts
+++ b/app/processors/webhook_processor.ts
@@ -11,6 +11,13 @@ export default class WebhookProcessor {
 
   public async processStripeWebhookEvent(stripeEvent: Record<string, any>) {
     const paymentIntent = stripeEvent.data.object
+    const currentPaymentIntentStatus =
+      await this.paymentIntentService.getCurrentPaymentIntentStatus(paymentIntent.id)
+
+    // If the current status equals the new status, do nothing
+    if (currentPaymentIntentStatus.status === paymentIntent.status) {
+      return
+    }
 
     switch (stripeEvent.type) {
       case 'payment_intent.succeeded':

--- a/app/services/payment_intent_service.ts
+++ b/app/services/payment_intent_service.ts
@@ -32,4 +32,8 @@ export default class PaymentIntentService {
 
     return paymentIntent
   }
+
+  async getCurrentPaymentIntentStatus(id: string): Promise<PaymentIntent> {
+    return await PaymentIntent.query().select('status').where('id', id).firstOrFail()
+  }
 }

--- a/tests/unit/processors/webhook_processor.spec.ts
+++ b/tests/unit/processors/webhook_processor.spec.ts
@@ -116,7 +116,9 @@ test.group('WebhookProcessor', (group) => {
     assert.equal(updatedAd?.statusId, 1)
   })
 
-  test('should not call services on unrelated event type', async ({ assert }) => {
+  test('should not call services if new payment intent service equals current status', async ({
+    assert,
+  }) => {
     await ArtistFactory.merge({ id: 1 }).create()
     await RarityFactory.merge({ id: 1 }).create()
     await LegalityFactory.merge({ id: 1 }).create()
@@ -128,7 +130,7 @@ test.group('WebhookProcessor', (group) => {
       rarityId: 1,
       legalityId: 1,
     }).create()
-    await AdStatusFactory.merge({ id: 1 }).create()
+    await AdStatusFactory.merge({ id: 2 }).create()
     await CardConditionFactory.merge({ id: 1 }).create()
     await CardFinishFactory.merge({ id: 1 }).create()
     const user = await UserFactory.merge({ id: 'user_67890', stripeId: 'acct_12345' }).create()
@@ -136,26 +138,25 @@ test.group('WebhookProcessor', (group) => {
       id: 'ad_12345',
       cardId: 'card_12345',
       sellerId: 'user_67890',
+      statusId: 2,
     }).create()
 
-    await PaymentIntentFactory.merge({
+    const paymentIntent = await PaymentIntentFactory.merge({
       id: 'pi_12345',
       fromId: user.id,
       toId: 'user_67890',
       adId: ad.id,
-      status: 'created',
+      status: 'canceled',
     }).create()
 
     const stripeEvent = {
-      type: 'charge.succeeded',
-      data: { object: { id: 'ch_12345' } },
+      type: 'payment_intent.canceled',
+      data: { object: { id: paymentIntent.id, status: paymentIntent.status } },
     }
 
     await webhookProcessor.processStripeWebhookEvent(stripeEvent)
-    const unchangedPaymentIntent = await PaymentIntent.query().where('id', 'pi_12345').first()
-    assert.equal(unchangedPaymentIntent?.status, 'created')
 
     const unchangedAd = await Ad.query().where('id', ad.id).first()
-    assert.equal(unchangedAd?.statusId, 1)
+    assert.equal(unchangedAd?.statusId, 2)
   })
 })


### PR DESCRIPTION
## 📝 Description

- Webhook events fro Stripe should not lead to any updates if it has already been processed before

Related task : [ATL-128](https://sleeved.atlassian.net/browse/ATL-128)

## 🔄 Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📸 Screenshots / Demo

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [x] Code follows project standards (lint, format)
- [x] Unit tests added/updated
- [x] Integration tests passing
- [x] Performance considerations addressed
- [ ] Documentation updated (if applicable)
- [ ] Database migrations added (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[ATL-128]: https://sleeved.atlassian.net/browse/ATL-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ