### PR TITLE
feat(payment-sheet): canceling payment sheet if user doesn't pay

### DIFF
--- a/app/controllers/product/payment_controller.ts
+++ b/app/controllers/product/payment_controller.ts
@@ -92,6 +92,27 @@ export default class PaymentController {
     }
   }
 
+  async cancelPaymentSheet({ request, authUser, response }: HttpContext) {
+    try {
+      const payload = await paymentSchemaValidator.validate(request.body())
+
+      // Get the payment intent associated with the ad id
+      await this.paymentIntentService.cancelPaymentIntent(payload.id, authUser.id)
+
+      // Update the ad status to "available"
+      await this.adService.updateAd(payload.id, { statusId: 1 })
+
+      response.json({
+        hasBeenCanceled: true,
+      })
+    } catch (error) {
+      if (error instanceof lucidErrors.E_ROW_NOT_FOUND) {
+        throw new NotFoundException(error)
+      }
+      throw error
+    }
+  }
+
   async getPublishableKey({ response }: HttpContext) {
     try {
       response.json({

--- a/app/services/payment_intent_service.ts
+++ b/app/services/payment_intent_service.ts
@@ -48,4 +48,15 @@ export default class PaymentIntentService {
   async getCurrentPaymentIntentStatus(id: string): Promise<PaymentIntent> {
     return await PaymentIntent.query().select('status').where('id', id).firstOrFail()
   }
+
+  async cancelPaymentIntent(adId: string, userId: string): Promise<PaymentIntent> {
+    const paymentIntent = await PaymentIntent.query()
+      .where('ad_id', adId)
+      .where('fromId', userId)
+      .whereIn('status', [PaymentIntentStatus.CREATED, PaymentIntentStatus.PROCESSING])
+      .firstOrFail()
+    paymentIntent.status = PaymentIntentStatus.CANCELED
+    await paymentIntent.save()
+    return paymentIntent
+  }
 }

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -92,6 +92,9 @@ router
             router
               .get('/:id/sheet/', [PaymentController, 'createPaymentSheet'])
               .use(middleware.auth())
+            router
+              .patch('/sheet/', [PaymentController, 'cancelPaymentSheet'])
+              .use(middleware.auth())
             router.get('/publishablekey/', [PaymentController, 'getPublishableKey'])
             router.get('/account/success', [PaymentController, 'stripeAccountLinkSuccess'])
             router.get('/account/refresh', [PaymentController, 'stripeAccountLinkRefresh'])

--- a/tests/functional/controllers/payment_controller.spec.ts
+++ b/tests/functional/controllers/payment_controller.spec.ts
@@ -264,6 +264,49 @@ test.group('Payment controller', (group) => {
     assert.equal(body.code, 'E_PAYMENT_INTENT_DUPLICATE')
   })
 
+  test('cancelPaymentSheet - should cancel payment sheet', async ({ client, assert }) => {
+    await ArtistFactory.merge({ id: 1 }).create()
+    await RarityFactory.merge({ id: 1 }).create()
+    await LegalityFactory.merge({ id: 1 }).create()
+    await SetFactory.merge({ id: 'base1' }).create()
+    await CardFactory.merge({
+      id: 'card_12345',
+      setId: 'base1',
+      artistId: 1,
+      rarityId: 1,
+      legalityId: 1,
+    }).create()
+    await AdStatusFactory.merge({ id: 1 }).create()
+    await CardConditionFactory.merge({ id: 1 }).create()
+    await CardFinishFactory.merge({ id: 1 }).create()
+    const sellerId = await UserFactory.merge({ id: 'user_6789', stripeId: 'acct_12345' }).create()
+    const ad = await AdFactory.merge({
+      id: 'ad_12345',
+      cardId: 'card_12345',
+      sellerId: sellerId.id,
+    }).create()
+
+    await PaymentIntentFactory.merge({
+      id: 'pi_12345',
+      fromId: TEST_AUTH_USER_ID,
+      toId: sellerId.id,
+      adId: ad.id,
+      status: 'created',
+    }).create()
+
+    const response = await client
+      .patch('/api/v1/payment/sheet')
+      .header('Authorization', 'Bearer fake-token-for-testing')
+      .json({ id: ad.id })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      hasBeenCanceled: true,
+    })
+
+    assert.isTrue(adServiceUpdateAdStub.calledWith(ad.id, { statusId: 1 }))
+  }).pin()
+
   test('stripeWebhook - should handle webhook event', async ({ client, assert }) => {
     await ArtistFactory.merge({ id: 1 }).create()
     await RarityFactory.merge({ id: 1 }).create()


### PR DESCRIPTION
## 📝 Description

If user cancels the payment before finishing it:
- Update payment intent status to canceled
- Update Ad to published and not sold
Related task : [ATL-141](https://sleeved.atlassian.net/browse/ATL-141)

## 🔄 Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📸 Screenshots / Demo

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Unit tests added/updated
- [ ] Integration tests passing
- [ ] Performance considerations addressed
- [ ] Documentation updated (if applicable)
- [ ] Database migrations added (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[ATL-141]: https://sleeved.atlassian.net/browse/ATL-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ